### PR TITLE
Fix not found 404 `html-webpack-plugin` link

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Check your browser console at [localhost:8080](http://localhost:8080/)
 
 * `entry` / `output` custom config.
 * chunk splitting (`app` | `vendors`)
-* html creation: [html-webpack-plugin](https://github.com/webpack-contrib/html-webpack-plugin)
+* html creation: [html-webpack-plugin](https://github.com/jantimon/html-webpack-plugin)
 * copying files: [copy-webpack-plugin](https://github.com/webpack-contrib/copy-webpack-plugin)
 * [webpack-dev-server](https://github.com/webpack/webpack-dev-server)
 * sass support


### PR DESCRIPTION
Link is now under [jantimon](https://github.com/jantimon/html-webpack-plugin) as per [official webpack docs](https://webpack.js.org/plugins/html-webpack-plugin/)